### PR TITLE
Update confluentdbutil.ronn

### DIFF
--- a/confluent_client/doc/man/confluentdbutil.ronn
+++ b/confluent_client/doc/man/confluentdbutil.ronn
@@ -15,7 +15,7 @@ the json files (password protected, removed from the files, or unprotected).
 
 ## OPTIONS
 
-* `-p`, `--password`:
+* `-p PASSWORD`, `--password=PASSWORD`:
   If specified, information such as usernames and passwords will be encrypted
   using the given password.
   


### PR DESCRIPTION
Man page is missing part of the password option as shown under usage

from usage output:
-p PASSWORD, --password=PASSWORD