### PR TITLE
Update nodeeventlog

### DIFF
--- a/confluent_client/bin/nodeeventlog
+++ b/confluent_client/bin/nodeeventlog
@@ -37,7 +37,7 @@ if sys.version_info[0] < 3:
     sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 argparser = optparse.OptionParser(
-    usage="Usage: %prog [options] noderange [clear]")
+    usage="Usage: %prog [options] <noderange> [clear]")
 argparser.add_option('-m', '--maxnodes', type='int',
                      help='Specify a maximum number of '
                           'nodes to clear if clearing log, '


### PR DESCRIPTION
usage output doesn't have < > around noderange were as SYNOPSIS on man page does

Usage: nodeeventlog [options] noderange [clear]
SYNOPSIS: nodeeventlog [options] <noderange> [clear]

Line 40 has been updated:

    usage="Usage: %prog [options] <noderange> [clear]")