### PR TITLE
Update nodelicense.ronn

### DIFF
--- a/confluent_client/doc/man/nodelicense.ronn
+++ b/confluent_client/doc/man/nodelicense.ronn
@@ -3,7 +3,7 @@ nodelicense(8) -- Manage license keys on BMC
 
 ## SYNOPSIS
 
-`nodelicense <noderange> [list|install <filename>|delete <license>|save <directory>]`
+`nodelicense <noderange> [list][install <filename>|save <directory>|delete <license>]`
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Updated the syntax mismatch between usage output and man page SYNOPSIS

Line 6 was modified:

`nodelicense <noderange> [list][install <filename>|save <directory>|delete <license>]`