### PR TITLE
Ansible fixes

### DIFF
--- a/confluent_server/confluent/runansible.py
+++ b/confluent_server/confluent/runansible.py
@@ -162,8 +162,9 @@ if __name__ == '__main__':
     if os.path.exists('/etc/ansible/hosts'):
         aninv = InventoryManager(loader=loader, sources='/etc/ansible/hosts')
         anshost = aninv.get_host(sys.argv[1])
-        if anshost:
-            invman = aninv
+        if not anshost:
+            aninv.add_host(sys.argv[1])
+        invman = aninv
     if not invman:
         invlist = sys.argv[1] + ','
         invman = InventoryManager(loader=loader, sources=invlist)

--- a/confluent_server/confluent/selfservice.py
+++ b/confluent_server/confluent/selfservice.py
@@ -570,7 +570,7 @@ def get_scriptlist(scriptcat, cfg, nodename, pathtemplate):
     if not os.path.isdir(target) and os.path.isdir(target + '.d'):
         target = target + '.d'
     try:
-        slist = os.listdir(target)
+        slist = sorted(os.listdir(target))
     except OSError:
         pass
     return slist, profile


### PR DESCRIPTION
Fix to directory listing to ensure consistency of order. Currently the code uses ```os.listdir(target)``` and as documented in the Python docs, this is not ordered. By changing to sort, this means that plays (and scripts?) will be executed in alphanumerical order rather than randomly.

Change to logic for hosts file, if the host is not present in the hosts file then currently group_vars is lost. This fix allows the following to be used in plays:

```
# group the hosts by os_distrib_version
# this allows (e.g.) group_vars/os_Redhat_8.yml to be included
- name: "Gather hosts by OS distrib"
  become: true
  hosts: "{{ HOSTS }}"
  tasks:
    - name: "Classify hosts by ansible_os_family_distribution_major_version"
      group_by:
        key: os_{{ ansible_os_family }}_{{ ansible_distribution_major_version }}
```

e.g. create a file ```/etc/ansible/group_vars/os_Redhat_8/main.yml``` or ```/etc/ansible/group_vars/os_Redhat_8.yml``` which can then have OS dependent data merged in.