### PR TITLE
fix ansible support when multi stage plays are in playbook

### DIFF
--- a/confluent_server/confluent/runansible.py
+++ b/confluent_server/confluent/runansible.py
@@ -173,9 +173,11 @@ if __name__ == '__main__':
     os.chdir(os.path.dirname(sys.argv[2]))
     if isinstance(plays, dict):
         plays = [plays]
-    taskman = TaskQueueManager(inventory=invman, loader=loader, passwords={},
-        variable_manager=varman, stdout_callback=ResultsCollector())
+
     for currplay in plays:
+        taskman = TaskQueueManager(inventory=invman, loader=loader, passwords={},
+            variable_manager=varman, stdout_callback=ResultsCollector())
+
         currplay['hosts'] = sys.argv[1]
         if 'become' in currplay and 'become_user' not in currplay:
             del currplay['become']


### PR DESCRIPTION
Current code only works when only a single play is in the yml file. For example:

```
- name: Example
  gather_facts: no
  tasks:
       - name: Example1
         lineinfile:
           path: /etc/hosts
           line: 1.2.3.4 test1
           create: yes
```
would work, but:
```
- name: Play1
  gather_facts: no
  tasks:
       - name: Example1
         lineinfile:
           path: /etc/hosts
           line: 1.2.3.4 test1
           create: yes
- name: Play2
  gather_facts: no
  tasks:
       - name: Example1
         lineinfile:
           path: /etc/hosts
           line: 1.2.3.10 test10
           create: yes
```
Whilst on paper it might be possible for a user to merge the tasks into just ```Play1```, this doesn't work in the case where both ```tasks``` and ```roles``` are used in the play. The example above is also valid ansible and would be expected to work.

Example valid but currently broken (in confluent) ansible:
```
---

# group the hosts by os_distrib_version
# this allows (e.g.) group_vars/os_Redhat_8.yml to be included
- name: "Gather hosts by OS distrib"
  become: true
  hosts: "{{ HOSTS }}"
  tasks:
    - name: "Classify hosts by ansible_os_family_distribution_major_version"
      group_by:
        key: os_{{ ansible_os_family }}_{{ ansible_distribution_major_version }}
      tags: [always]
    - name: "Test zsh package"
      ansible.builtin.package:
        name: zsh
        state: present

- name: 'foo'
  become: true
  roles:
    - login_node
```

The patch moves creation of taskman inside the plays loop - the code in the ```finally``` block finalises the TaskQueue and so it needs to be initialised on each iteration of the loop.