### PR TITLE
Confignet does not set autoconnect with network manager

### DIFF
--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -253,6 +253,7 @@ class NetworkManager(object):
 
     def apply_configuration(self, cfg):
         cmdargs = {}
+        cmdargs['connection.autoconnect'] = 'yes'
         stgs = cfg['settings']
         cmdargs['ipv6.method'] = stgs.get('ipv6_method', 'link-local')
         if stgs.get('ipv6_address', None):


### PR DESCRIPTION
Currently confignet does not set the connection.autoconnect parameter when configuring an interfaces. On a disk install this means on reboot (e.g.) an IPoIB interface does not come up. The PR adds the field so by default autoconnect is set to yes.