### PR TITLE
NTP servers fix for stateless images for RHEL 7-9

### DIFF
--- a/confluent_osdeploy/el7-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/el7-diskless/profiles/default/scripts/onboot.sh
@@ -5,11 +5,37 @@
 # noted below so custom commands are executed before
 # the script notifies confluent that install is fully complete.
 
+
+ntpsrvs=""
 nodename=$(grep ^NODENAME /etc/confluent/confluent.info|awk '{print $2}')
 confluent_apikey=$(cat /etc/confluent/confluent.apikey)
 confluent_mgr=$(grep ^deploy_server: /etc/confluent/confluent.deploycfg|awk '{print $2}')
 confluent_profile=$(grep ^profile: /etc/confluent/confluent.deploycfg|awk '{print $2}')
 timedatectl set-timezone $(grep ^timezone: /etc/confluent/confluent.deploycfg|awk '{print $2}')
+
+
+if grep ^ntpservers: /etc/confluent/confluent.deploycfg > /dev/null; then
+    for ntpsrv in $(sed -n '/^ntpservers:/,/^[^-]/p' /etc/confluent/confluent.deploycfg|sed 1d|sed '$d' | sed -e 's/^- //'); do
+        echo "server ${ntpsrv} iburst " >> /tmp/timeservers
+    done
+fi
+
+if [ -f /tmp/timeservers ]; then
+
+ntpsrvs=$(cat /tmp/timeservers)
+
+sed -i "1,/^pool * /c\\
+
+${ntpsrvs//$'\n'/\\$'\n'}" /etc/chrony.conf
+
+
+systemctl restart chronyd
+
+rm -f /tmp/timeservers
+fi
+
+
+
 export nodename confluent_mgr confluent_profile
 . /etc/confluent/functions
 mkdir -p /var/log/confluent

--- a/confluent_osdeploy/el9-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/el9-diskless/profiles/default/scripts/onboot.sh
@@ -4,7 +4,7 @@
 # completed. It is best to edit the middle of the file as
 # noted below so custom commands are executed before
 # the script notifies confluent that install is fully complete.
-
+ntpsrvs=""
 nodename=$(grep ^NODENAME /etc/confluent/confluent.info|awk '{print $2}')
 confluent_apikey=$(cat /etc/confluent/confluent.apikey)
 v4meth=$(grep ^ipv4_method: /etc/confluent/confluent.deploycfg|awk '{print $2}')
@@ -17,6 +17,28 @@ fi
 confluent_profile=$(grep ^profile: /etc/confluent/confluent.deploycfg|awk '{print $2}')
 timedatectl set-timezone $(grep ^timezone: /etc/confluent/confluent.deploycfg|awk '{print $2}')
 hostnamectl set-hostname $nodename
+
+
+if grep ^ntpservers: /etc/confluent/confluent.deploycfg > /dev/null; then
+    for ntpsrv in $(sed -n '/^ntpservers:/,/^[^-]/p' /etc/confluent/confluent.deploycfg|sed 1d|sed '$d' | sed -e 's/^- //'); do
+        echo "server ${ntpsrv} iburst " >> /tmp/timeservers
+    done
+fi
+
+if [ -f /tmp/timeservers ]; then
+
+ntpsrvs=$(cat /tmp/timeservers)
+
+sed -i "1,/^pool * /c\\
+
+${ntpsrvs//$'\n'/\\$'\n'}" /etc/chrony.conf
+
+
+systemctl restart chronyd
+
+rm -f /tmp/timeservers
+fi
+
 export nodename confluent_mgr confluent_profile
 . /etc/confluent/functions
 mkdir -p /var/log/confluent


### PR DESCRIPTION
Node attribute ntp.servers in nodeattrib ca now be used in stateless images

	modified:   confluent_osdeploy/el7-diskless/profiles/default/scripts/onboot.sh
	modified:   confluent_osdeploy/el8-diskless/profiles/default/scripts/onboot.sh
	modified:   confluent_osdeploy/el9-diskless/profiles/default/scripts/onboot.sh